### PR TITLE
Explicitly declare arguments.fileField in CFFILE action="upload"

### DIFF
--- a/secureupload/secureupload.cfc
+++ b/secureupload/secureupload.cfc
@@ -34,7 +34,7 @@
 			</cfif>
 
 			<!--- upload the file --->
-			<cffile action="upload" destination="#arguments.tempDirectory#" nameconflict="#tempNameConflict#" result="result.cfFileResult">
+			<cffile action="upload" fileField="#arguments.fileField#" destination="#arguments.tempDirectory#" nameconflict="#tempNameConflict#" result="result.cfFileResult">
 			
 			<!--- handle case if no file extension --->
 			<cfif NOT Len(result.cfFileResult.serverFileExt)>


### PR DESCRIPTION
The code currently defaults to the first file field. Secureupload.cfc will not work if other input type="file" fields exist in the form scope.
